### PR TITLE
Added format for millisecond zoom level

### DIFF
--- a/src/com/invient/vaadin/charts/InvientChartsConfig.java
+++ b/src/com/invient/vaadin/charts/InvientChartsConfig.java
@@ -4839,6 +4839,7 @@ public final class InvientChartsConfig implements Serializable {
         // private Date minorTickInterval;
 
         public static final class DateTimeLabelFormat {
+            private String millisecond = "%H:%M:%S.%L";
             private String second = "%H:%M:%S";
             private String minute = "%H:%M";
             private String hour = "%H:%M";
@@ -4846,6 +4847,14 @@ public final class InvientChartsConfig implements Serializable {
             private String week = "%e. %b";
             private String month = "%b '%y";
             private String year = "%Y";
+
+            public String getMillisecond() {
+                return millisecond;
+            }
+
+            public void setMillisecond(String millisecond) {
+                this.millisecond = millisecond;
+            }
 
             public String getSecond() {
                 return second;

--- a/src/com/invient/vaadin/charts/InvientChartsUtil.java
+++ b/src/com/invient/vaadin/charts/InvientChartsUtil.java
@@ -1860,6 +1860,10 @@ final class InvientChartsUtil {
             target.startTag("dateTimeLabelFormats");
             DateTimeLabelFormat dateTimeLabelFormat = dateTimeAxis
                     .getDateTimeLabelFormat();
+            if (dateTimeLabelFormat.getMillisecond() != null) {
+                target.addAttribute("millisecond", dateTimeAxis
+                        .getDateTimeLabelFormat().getMillisecond());
+            }
             if (dateTimeLabelFormat.getSecond() != null) {
                 target.addAttribute("second", dateTimeAxis
                         .getDateTimeLabelFormat().getSecond());

--- a/src/com/invient/vaadin/charts/widgetset/client/ui/GwtInvientChartsConfig.java
+++ b/src/com/invient/vaadin/charts/widgetset/client/ui/GwtInvientChartsConfig.java
@@ -1607,6 +1607,10 @@ class GwtInvientChartsConfig extends JavaScriptObject {
                                                                         return { };
                                                                         }-*/;
 
+            public native final void setMillisecond(String millisecond) /*-{
+                                                              this.millisecond = millisecond;
+                                                              }-*/;
+            
             public native final void setSecond(String second) /*-{
                                                               this.second = second;
                                                               }-*/;

--- a/src/com/invient/vaadin/charts/widgetset/client/ui/VInvientCharts.java
+++ b/src/com/invient/vaadin/charts/widgetset/client/ui/VInvientCharts.java
@@ -1707,6 +1707,10 @@ public class VInvientCharts extends GwtInvientCharts implements Paintable /*
                     UIDL dateTimeLblFmtsUIDL = childUIDL;
                     GwtDateTimeLabelFormats formats = GwtDateTimeLabelFormats
                             .create();
+                    if (dateTimeLblFmtsUIDL.hasAttribute("millisecond")) {
+                        formats.setMillisecond(dateTimeLblFmtsUIDL
+                                .getStringAttribute("millisecond"));
+                    }
                     if (dateTimeLblFmtsUIDL.hasAttribute("second")) {
                         formats.setSecond(dateTimeLblFmtsUIDL
                                 .getStringAttribute("second"));


### PR DESCRIPTION
DateTimeLabelFormat was only capable of handling the following levels:
- Year
- Week
- Month
- Day
- Hour
- Minute
- Second

HighCharts also has a zoom level for millisecond and that's what I added support for.
